### PR TITLE
format time without semicolons nor slash

### DIFF
--- a/R/evaluate-cutpoints.R
+++ b/R/evaluate-cutpoints.R
@@ -127,7 +127,7 @@ evaluateCutpoints <- function (mainDir, resultsDirName, biomarkerList, time, eve
     dir.create(resultsDirName)
   }
 
-  currentDate <- format(Sys.time(), "%a %b %d %Y %x")
+  currentDate <- format(Sys.time(), "%a %b %d %Y %H %M %S")
   setwd(resultsDirName)
   dir.create(currentDate)
 


### PR DESCRIPTION
fixes #1 

Due to the `/`, `dir.create(currentDate)` fails since it detects `Fri Dec 23 2022 23/12/2022` as 3 different folders, the former of which are not recursively created.

A solution that would work for both Windows and Unix systems would be `currentDate <- format(Sys.time(), "%a %b %d %Y %H %M %S")`.